### PR TITLE
Support current embedded stack versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,11 @@ embassy = ["dep:embassy-sync"]
 ble = []
 
 [dependencies]
-ch58x = { version = "0.3.0", features = ["ch58x", "rt"] }
+ch58x = { version = "0.4.0", features = ["ch58x", "rt"] }
 
-critical-section = "1.1.2"
-qingke = { version = "0.1.7", features = ["critical-section-impl"] }
-qingke-rt = { version = "0.1.7", features = ["highcode"] }
-
-# qingke = { version = "0.1.7", features = [
-#     "critical-section-impl",
-# ], path = "../qingke" }
-# qingke-rt = { version = "0.1.7", features = [
-#     "highcode",
-# ], path = "../qingke/qingke-rt" }
+critical-section = "1.2"
+qingke = { version = "0.5.0", features = ["critical-section-impl"] }
+qingke-rt = { version = "0.5.0", features = ["highcode"] }
 
 fugit = "0.3.7"
 nb = "1.1.0"
@@ -40,8 +33,9 @@ embedded-hal-1 = { version = "1.0.0", package = "embedded-hal" }
 embedded-hal-nb = "1.0.0"
 embedded-hal-async = "1.0.0"
 
-embassy-sync = { version = "0.5.0", optional = true }
-embassy-time-driver = { version = "0.1.0", features = ["tick-hz-32_768"] }
+embassy-sync = { version = "0.6.2", optional = true }
+embassy-time-driver = { version = "0.2.0", features = ["tick-hz-32_768"] }
+embassy-time-queue-utils = "0.1.0" # time driver impl
 
 [dev-dependencies]
 display-interface = "0.4.1"
@@ -51,17 +45,16 @@ panic-halt = "0.2.0"
 ssd1306 = "0.8.4"
 
 embassy-futures = "0.1.1"
-embassy-executor = { version = "0.5.0", features = [
+embassy-executor = { version = "0.7.0", features = [
     "nightly",
-    "integrated-timers",
     "arch-riscv32",
     "executor-thread",
 ] }
-embassy-time = { version = "0.3.0" }
+embassy-time = { version = "0.4.0" }
 # embassy time driver
 heapless = "0.8.0"
-embedded-alloc = "0.5.0"
-embedded-sdmmc = "0.6.0"
+embedded-alloc = "0.6.0"
+embedded-sdmmc = "0.8.1"
 
 [profile.release]
 # panic = "unwind"

--- a/examples/ble-blinky.rs
+++ b/examples/ble-blinky.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use core::mem::{size_of_val, MaybeUninit};
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/examples/ble-broadcaster.rs
+++ b/examples/ble-broadcaster.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use qingke_rt::highcode;
 use ch58x_hal as hal;

--- a/examples/ble-led-button.rs
+++ b/examples/ble-led-button.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use core::mem::size_of_val;
 use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};

--- a/examples/ble-peripheral.rs
+++ b/examples/ble-peripheral.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use core::ffi::c_void;
 use core::mem::size_of_val;

--- a/examples/ble-scanner.rs
+++ b/examples/ble-scanner.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use ch58x_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/embassy-blinky.rs
+++ b/examples/embassy-blinky.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use ch58x_hal as hal;
 use embassy_executor::Spawner;

--- a/examples/embassy-gpio.rs
+++ b/examples/embassy-gpio.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use ch58x_hal as hal;
 use embassy_executor::Spawner;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -167,16 +167,18 @@ where
 
         let rb = T::regs();
         rb.cfg().modify(|_, w| {
-            w.power_on()
-                .set_bit()
-                .diff_en()
-                .bit(config.diff_en) // must for temp
-                .clk_div()
-                .variant(config.clk as u8)
-                .buf_en()
-                .bit(config.buf_en)
-                .pga_gain()
-                .variant(config.pga_gain as u8)
+            unsafe {
+                w.power_on()
+                    .set_bit()
+                    .diff_en()
+                    .bit(config.diff_en) // must for temp
+                    .clk_div()
+                    .bits(config.clk as u8)
+                    .buf_en()
+                    .bit(config.buf_en)
+                    .pga_gain()
+                    .bits(config.pga_gain as u8)
+            }
         });
 
         Self { adc }
@@ -185,14 +187,16 @@ where
     pub fn set_config(&self, config: Config) {
         let rb = T::regs();
         rb.cfg().modify(|_, w| {
-            w.diff_en()
-                .bit(config.diff_en) // must for temp
-                .clk_div()
-                .variant(config.clk as u8)
-                .buf_en()
-                .bit(config.buf_en)
-                .pga_gain()
-                .variant(config.pga_gain as u8)
+            unsafe {
+                w.diff_en()
+                    .bit(config.diff_en) // must for temp
+                    .clk_div()
+                    .bits(config.clk as u8)
+                    .buf_en()
+                    .bit(config.buf_en)
+                    .pga_gain()
+                    .bits(config.pga_gain as u8)
+            }
         });
     }
 
@@ -230,7 +234,7 @@ where
         let channel = pin.channel();
 
         // Select channel
-        rb.channel().modify(|_, w| w.ch_idx().variant(channel));
+        rb.channel().modify(|_, w| unsafe { w.ch_idx().bits(channel) });
 
         self.convert()
     }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -11,19 +11,13 @@ impl embedded_hal_1::delay::DelayNs for CycleDelay {
     #[highcode]
     fn delay_us(&mut self, us: u32) {
         let cycles = us as u64 * clocks().hclk.to_Hz() as u64 / 1_500_000;
-
-        unsafe {
-            riscv::asm::delay(cycles as u32);
-        }
+        riscv::asm::delay(cycles as u32);
     }
 
     #[highcode]
     fn delay_ns(&mut self, ns: u32) {
         let cycles = ns as u64 * clocks().hclk.to_Hz() as u64 / 1_500_000_000;
-
-        unsafe {
-            riscv::asm::delay(cycles as u32);
-        }
+        riscv::asm::delay(cycles as u32);
     }
 
     #[highcode]
@@ -31,9 +25,7 @@ impl embedded_hal_1::delay::DelayNs for CycleDelay {
         let cycles = 1000 * clocks().hclk.to_Hz() as u64 / 1_500_000;
 
         while ms > 0 {
-            unsafe {
-                riscv::asm::delay(cycles as u32);
-            }
+            riscv::asm::delay(cycles as u32);
             ms -= 1;
         }
     }

--- a/src/embassy/time_driver_systick.rs
+++ b/src/embassy/time_driver_systick.rs
@@ -1,49 +1,24 @@
 //! SysTick-based time driver.
 
-use core::cell::Cell;
-use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
-use core::{mem, ptr};
+use core::cell::RefCell;
+use core::sync::atomic::{AtomicU32, Ordering};
+use core::task::Waker;
 
 use critical_section::{CriticalSection, Mutex};
-use embassy_time_driver::{AlarmHandle, Driver};
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::Queue;
 
 // use super::AlarmState;
 use crate::pac;
 
-pub const ALARM_COUNT: usize = 1;
-
-struct AlarmState {
-    timestamp: Cell<u64>,
-
-    // This is really a Option<(fn(*mut ()), *mut ())>
-    // but fn pointers aren't allowed in const yet
-    callback: Cell<*const ()>,
-    ctx: Cell<*mut ()>,
-}
-
-unsafe impl Send for AlarmState {}
-
-impl AlarmState {
-    const fn new() -> Self {
-        Self {
-            timestamp: Cell::new(u64::MAX),
-            callback: Cell::new(ptr::null()),
-            ctx: Cell::new(ptr::null_mut()),
-        }
-    }
-}
-
 pub struct SystickDriver {
-    alarm_count: AtomicU8,
-    alarms: Mutex<[AlarmState; ALARM_COUNT]>,
     period: AtomicU32,
+    queue: Mutex<RefCell<Queue>>,
 }
 
-const ALARM_STATE_NEW: AlarmState = AlarmState::new();
 embassy_time_driver::time_driver_impl!(static DRIVER: SystickDriver = SystickDriver {
     period: AtomicU32::new(1), // avoid div by zero
-    alarm_count: AtomicU8::new(0),
-    alarms: Mutex::new([ALARM_STATE_NEW; ALARM_COUNT]),
+    queue: Mutex::new(RefCell::new(Queue::new())),
 });
 
 impl SystickDriver {
@@ -77,32 +52,45 @@ impl SystickDriver {
     }
 
     fn on_interrupt(&self) {
-        let rb = unsafe { &*pac::SYSTICK::PTR };
-        rb.ctlr().modify(|_, w| w.stie().clear_bit()); // disable interrupt
-        rb.sr().write(|w| w.cntif().bit(false)); // clear IF
-
         critical_section::with(|cs| {
-            self.trigger_alarm(cs);
+            let systick = unsafe { &*pac::SYSTICK::PTR };
+            systick.sr().write(|w| w.cntif().clear_bit()); // clear interrupt flag
+
+            let mut queue = self.queue.borrow_ref_mut(cs);
+            self.update_alarms(cs, &mut queue);
         });
     }
 
-    fn trigger_alarm(&self, cs: CriticalSection) {
-        let alarm = &self.alarms.borrow(cs)[0];
-        alarm.timestamp.set(u64::MAX);
+    fn update_alarms(&self, _: CriticalSection, queue: &mut Queue) -> bool {
+        let systick = unsafe { &*pac::SYSTICK::PTR };
 
-        // Call after clearing alarm, so the callback can set another alarm.
+        loop {
+            // Wakes all tasks scheduled now or before
+            let next_alarm = queue.next_expiration(self.now());
 
-        // safety:
-        // - we can ignore the possiblity of `f` being unset (null) because of the safety contract of `allocate_alarm`.
-        // - other than that we only store valid function pointers into alarm.callback
-        let f: fn(*mut ()) = unsafe { mem::transmute(alarm.callback.get()) };
-        f(alarm.ctx.get());
-    }
+            // No more scheduled tasks
+            if next_alarm == u64::MAX {
+                // Disabling the interrupt is unnecesary but may (untested) save power.
+                systick.ctlr().modify(|_, w| w.stie().clear_bit());
+                return false;
+            }
 
-    fn get_alarm<'a>(&'a self, cs: CriticalSection<'a>, alarm: AlarmHandle) -> &'a AlarmState {
-        // safety: we're allowed to assume the AlarmState is created by us, and
-        // we never create one that's out of bounds.
-        unsafe { self.alarms.borrow(cs).get_unchecked(alarm.id() as usize) }
+            // TODO: why did the old hal use an atomic
+            let cmp_timestamp = next_alarm * self.period.load(Ordering::Relaxed) as u64; // fails
+            systick.cmp().write(|w| unsafe { w.bits(cmp_timestamp) });
+            systick.ctlr().modify(|_, w| w.stie().set_bit()); // set interrupt
+
+            // UNDOCUMENTED: The timer will only interrupt when cnt and cmp match exactly.
+            // If cmp is now less than cnt, there is a good chance the flag was not
+            // and will never be triggered.
+            if systick.cmp().read().bits() > systick.cnt().read().bits() {
+                return true;
+            }
+
+            // If cmp < count, loop and wake the task now. Ensure the flag is unset
+            // to avoid a potential extra interrupt.
+            systick.sr().write(|w| w.cntif().clear_bit());
+        }
     }
 }
 
@@ -111,62 +99,19 @@ impl Driver for SystickDriver {
         let rb = unsafe { &*pac::SYSTICK::PTR };
         rb.cnt().read().bits() / (self.period.load(Ordering::Relaxed) as u64)
     }
-    unsafe fn allocate_alarm(&self) -> Option<AlarmHandle> {
-        let id = self.alarm_count.fetch_update(Ordering::AcqRel, Ordering::Acquire, |x| {
-            if x < ALARM_COUNT as u8 {
-                Some(x + 1)
-            } else {
-                None
+
+    fn schedule_wake(&self, at: u64, waker: &Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow_ref_mut(cs);
+            if queue.schedule_wake(at, waker) {
+                self.update_alarms(cs, &mut queue);
             }
         });
-
-        match id {
-            Ok(id) => Some(AlarmHandle::new(id)),
-            Err(_) => None,
-        }
-    }
-    fn set_alarm_callback(&self, alarm: AlarmHandle, callback: fn(*mut ()), ctx: *mut ()) {
-        critical_section::with(|cs| {
-            let alarm = self.get_alarm(cs, alarm);
-
-            alarm.callback.set(callback as *const ());
-            alarm.ctx.set(ctx);
-        })
-    }
-    fn set_alarm(&self, alarm: AlarmHandle, timestamp: u64) -> bool {
-        critical_section::with(|cs| {
-            let _n = alarm.id();
-
-            let alarm = self.get_alarm(cs, alarm);
-            alarm.timestamp.set(timestamp);
-
-            let rb = unsafe { &*pac::SYSTICK::PTR };
-
-            let t = self.now();
-            if timestamp <= t {
-                // If alarm timestamp has passed the alarm will not fire.
-                // Disarm the alarm and return `false` to indicate that.
-                rb.ctlr().modify(|_, w| w.stie().clear_bit());
-
-                alarm.timestamp.set(u64::MAX);
-
-                return false;
-            }
-
-            let safe_timestamp = (timestamp + 1) * (self.period.load(Ordering::Relaxed) as u64);
-
-            rb.cmp().write(|w| unsafe { w.bits(safe_timestamp) });
-            rb.ctlr().modify(|_, w| w.stie().set_bit());
-
-            true
-        })
     }
 }
 
-#[allow(non_snake_case)]
-#[link_section = ".trap"]
-#[no_mangle]
-extern "C" fn SysTick() {
+#[qingke_rt::interrupt]
+fn SysTick() {
     DRIVER.on_interrupt();
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -335,14 +335,14 @@ fn irq_handler<const N: usize>(port: u8, wakers: &[AtomicWaker; N]) {
 }
 
 #[cfg(feature = "embassy")]
-#[no_mangle]
-extern "C" fn GPIOA() {
+#[qingke_rt::interrupt]
+fn GPIOA() {
     irq_handler(0, &GPIOA_WAKERS);
 }
 
 #[cfg(feature = "embassy")]
-#[no_mangle]
-extern "C" fn GPIOB() {
+#[qingke_rt::interrupt]
+fn GPIOB() {
     irq_handler(1, &GPIOB_WAKERS);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,10 @@ pub fn init(config: Config) -> Peripherals {
 pub unsafe fn reset() -> ! {
     const KEY3: u16 = 0xBEEF;
     let pfic = unsafe { &*pac::PFIC::PTR };
-    pfic.cfgr().write(|w| w.keycode().variant(KEY3).resetsys().set_bit());
+
+    pfic.cfgr()
+        .write(|w| unsafe { w.keycode().bits(KEY3).resetsys().set_bit() });
+
     loop {}
 }
 

--- a/src/sysctl.rs
+++ b/src/sysctl.rs
@@ -111,18 +111,14 @@ impl Config {
                 with_safe_access(|| {
                     sys.ck32k_config().modify(|_, w| w.clk_xt32k_pon().set_bit());
                 });
-                unsafe {
-                    riscv::asm::delay(clocks().hclk.to_Hz() / 10 / 4);
-                }
+                riscv::asm::delay(clocks().hclk.to_Hz() / 10 / 4);
                 //with_safe_access(|| unsafe {
                 //    sys.xt32k_tune().modify(|_, w| w.xt32k_i_tune().bits(0b01));
                 //});
                 with_safe_access(|| {
                     sys.ck32k_config().modify(|_, w| w.clk_osc32k_xt().set_bit());
                 });
-                unsafe {
-                    riscv::asm::delay(clocks().hclk.to_Hz() / 1000);
-                }
+                riscv::asm::delay(clocks().hclk.to_Hz() / 1000);
             }
             Clock32KSrc::LSI => {
                 with_safe_access(|| {
@@ -141,22 +137,20 @@ impl Config {
                 if sys.hfck_pwr_ctrl().read().clk_xt32m_pon().bit_is_clear() {
                     // HSE power on
                     with_safe_access(|| sys.hfck_pwr_ctrl().modify(|_, w| w.clk_xt32m_pon().set_bit()));
-                    unsafe {
-                        riscv::asm::delay(2400);
-                    }
+                    riscv::asm::delay(2400);
                 }
-                with_safe_access(|| unsafe {
+                with_safe_access(|| {
                     sys.clk_sys_cfg()
-                        .write(|w| w.clk_sys_mod().variant(0b00).clk_pll_div().variant(div & 0x1f));
+                        .write(|w| unsafe { w.clk_sys_mod().bits(0b00).clk_pll_div().bits(div & 0x1f) });
                     riscv::asm::nop();
                     riscv::asm::nop();
                     riscv::asm::nop();
                     riscv::asm::nop();
                 });
-                unsafe {
-                    riscv::asm::nop();
-                    riscv::asm::nop();
-                }
+
+                riscv::asm::nop();
+                riscv::asm::nop();
+
                 with_safe_access(|| unsafe {
                     sys.flash_cfg().write(|w| w.bits(0x51));
                 });
@@ -167,13 +161,11 @@ impl Config {
                 if sys.hfck_pwr_ctrl().read().clk_pll_pon().bit_is_clear() {
                     // HSE power on
                     with_safe_access(|| sys.hfck_pwr_ctrl().modify(|_, w| w.clk_pll_pon().set_bit()));
-                    unsafe {
-                        riscv::asm::delay(4000);
-                    }
+                    riscv::asm::delay(4000);
                 }
-                with_safe_access(|| unsafe {
+                with_safe_access(|| {
                     sys.clk_sys_cfg()
-                        .write(|w| w.clk_sys_mod().bits(0b01).clk_pll_div().bits(div & 0x1f));
+                        .write(|w| unsafe { w.clk_sys_mod().bits(0b01).clk_pll_div().bits(div & 0x1f) });
                     riscv::asm::nop();
                     riscv::asm::nop();
                     riscv::asm::nop();

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -334,26 +334,28 @@ fn configure(
     }
 
     rb.fcr().write(|w| {
-        w.rx_fifo_clr()
-            .set_bit()
-            .tx_fifo_clr()
-            .set_bit()
-            .fifo_en() // enable 8 byte FIFO
-            .set_bit()
-            .fifo_trig()
-            .variant(0b00) // 1 bytes to send
+        unsafe {
+            w.rx_fifo_clr()
+                .set_bit()
+                .tx_fifo_clr()
+                .set_bit()
+                .fifo_en() // enable 8 byte FIFO
+                .set_bit()
+                .fifo_trig()
+                .bits(0b00) // 1 bytes to send
+        }
     });
-    rb.lcr().write(|w| w.word_sz().variant(config.data_bits as u8));
+    rb.lcr().write(|w| unsafe { w.word_sz().bits(config.data_bits as u8) });
     match config.stop_bits {
         StopBits::STOP1 => rb.lcr().modify(|_, w| w.stop_bit().clear_bit()),
         StopBits::STOP2 => rb.lcr().modify(|_, w| w.stop_bit().set_bit()),
-    }
+    };
     match config.parity {
         Parity::ParityNone => rb.lcr().modify(|_, w| w.par_en().clear_bit()),
         _ => rb
             .lcr()
-            .modify(|_, w| w.par_en().set_bit().par_mod().variant(config.parity as u8)),
-    }
+            .modify(|_, w| unsafe { w.par_en().set_bit().par_mod().bits(config.parity as u8) }),
+    };
 
     // baudrate = Fsys * 2 / R8_UARTx_DIV / 16 / R16_UARTx_DL
     // match some common baudrates


### PR DESCRIPTION
This PR updates all dependencies and makes the changes required for them to work, so new versions of embassy and related packages can be used.
- Rewrote the time driver as the upstream interface has changed
- Replaced .variant functions from svd2rust with .bits
- Replaced interrupt signatures with `#[qingke_rt::interrupt]`
- Removed unnecessary unsafe blocks

Only systick and gpio have currently been tested, with a ch583. Note that the risc32 embassy driver does not work properly with qingke chips without further changes which I'm working on for a future PR.

Ideally the .variant change can be reverted by adding enums to the svd files in ch32-rs.

Depends on https://github.com/ch32-rs/ch32-rs/pull/22

Note: The old time driver implementation had a potential race condition where the systick cmp value could end up set below cnt, which won't interrupt. I'm fairly sure other chXXX crates have similar issues.